### PR TITLE
Implement DB locking

### DIFF
--- a/apply/apply.go
+++ b/apply/apply.go
@@ -60,6 +60,8 @@ func initializeEngine(dsn, source, driverName, path string, options ...morph.Eng
 		return nil, err
 	}
 
+	options = append(options, morph.LockDB("mutex_migration"))
+
 	engine, err := morph.New(driver, src, options...)
 	if err != nil {
 		return nil, err

--- a/apply/apply.go
+++ b/apply/apply.go
@@ -60,7 +60,7 @@ func initializeEngine(dsn, source, driverName, path string, options ...morph.Eng
 		return nil, err
 	}
 
-	options = append(options, morph.LockDB("mutex_migration"))
+	options = append(options, morph.WithLockKey("mutex_migration"))
 
 	engine, err := morph.New(driver, src, options...)
 	if err != nil {

--- a/commands/apply.go
+++ b/commands/apply.go
@@ -23,6 +23,7 @@ func ApplyCmd() *cobra.Command {
 
 	cmd.PersistentFlags().IntP("timeout", "t", 60, "the timeout in seconds for each migration file to run")
 	cmd.PersistentFlags().StringP("migrations-table", "m", "db_migrations", "the name of the migrations table")
+	cmd.PersistentFlags().StringP("lock-key", "l", "mutex_migrations", "the name of the mutex key")
 
 	cmd.AddCommand(
 		UpApplyCmd(),
@@ -75,9 +76,10 @@ func upApplyCmdF(cmd *cobra.Command, _ []string) error {
 	steps, _ := cmd.Flags().GetInt("number")
 	timeout, _ := cmd.Flags().GetInt("timeout")
 	tableName, _ := cmd.Flags().GetString("migrations-table")
+	mutexKey, _ := cmd.Flags().GetString("lock-key")
 
 	morph.InfoLogger.Printf("Attempting to apply %d migrations...\n", steps)
-	n, err := apply.Up(steps, dsn, source, driverName, path, morph.SetMigrationTableName(tableName), morph.SetSatementTimeoutInSeconds(timeout))
+	n, err := apply.Up(steps, dsn, source, driverName, path, morph.SetMigrationTableName(tableName), morph.SetSatementTimeoutInSeconds(timeout), morph.WithLockKey(mutexKey))
 	if n > 0 {
 		morph.SuccessLogger.Printf("%d migrations applied.\n", n)
 	} else if n == 0 {
@@ -94,9 +96,10 @@ func downApplyCmdF(cmd *cobra.Command, _ []string) error {
 	steps, _ := cmd.Flags().GetInt("number")
 	timeout, _ := cmd.Flags().GetInt("timeout")
 	tableName, _ := cmd.Flags().GetString("migrations-table")
+	mutexKey, _ := cmd.Flags().GetString("lock-key")
 
 	morph.InfoLogger.Printf("Attempting to apply  %d migrations...\n", steps)
-	n, err := apply.Down(steps, dsn, source, driverName, path, morph.SetMigrationTableName(tableName), morph.SetSatementTimeoutInSeconds(timeout))
+	n, err := apply.Down(steps, dsn, source, driverName, path, morph.SetMigrationTableName(tableName), morph.SetSatementTimeoutInSeconds(timeout), morph.WithLockKey(mutexKey))
 	if n > 0 {
 		morph.SuccessLogger.Printf("%d migrations applied.\n", n)
 	} else if n == 0 {
@@ -112,9 +115,10 @@ func migrateApplyCmdF(cmd *cobra.Command, _ []string) error {
 	path, _ := cmd.Flags().GetString("path")
 	timeout, _ := cmd.Flags().GetInt("timeout")
 	tableName, _ := cmd.Flags().GetString("migrations-table")
+	mutexKey, _ := cmd.Flags().GetString("lock-key")
 
 	morph.InfoLogger.Println("Applying all pending migrations...")
-	if err := apply.Migrate(dsn, source, driverName, path, morph.SetMigrationTableName(tableName), morph.SetSatementTimeoutInSeconds(timeout)); err != nil {
+	if err := apply.Migrate(dsn, source, driverName, path, morph.SetMigrationTableName(tableName), morph.SetSatementTimeoutInSeconds(timeout), morph.WithLockKey(mutexKey)); err != nil {
 		return err
 	}
 	morph.SuccessLogger.Println("Pending migrations applied.")

--- a/commands/apply.go
+++ b/commands/apply.go
@@ -13,13 +13,13 @@ func ApplyCmd() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringP("driver", "d", "", "the database driver of the migrations")
-	cmd.MarkPersistentFlagRequired("driver")
+	_ = cmd.MarkPersistentFlagRequired("driver")
 	cmd.PersistentFlags().String("dsn", "", "the dsn of the database")
-	cmd.MarkPersistentFlagRequired("dsn")
+	_ = cmd.MarkPersistentFlagRequired("dsn")
 
 	cmd.PersistentFlags().StringP("source", "s", "file", "the source of the migrations")
 	cmd.PersistentFlags().StringP("path", "p", "", "the source path of the migrations")
-	cmd.MarkPersistentFlagRequired("path")
+	_ = cmd.MarkPersistentFlagRequired("path")
 
 	cmd.PersistentFlags().IntP("timeout", "t", 60, "the timeout in seconds for each migration file to run")
 	cmd.PersistentFlags().StringP("migrations-table", "m", "db_migrations", "the name of the migrations table")

--- a/drivers/lock.go
+++ b/drivers/lock.go
@@ -1,0 +1,73 @@
+package drivers
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"time"
+)
+
+const (
+	// MutexTableName is the name being used for the mutex table
+	MutexTableName = "db_lock"
+
+	// MinWaitInterval is the minimum amount of time to wait between locking attempts
+	MinWaitInterval = 1 * time.Second
+
+	// MaxWaitInterval is the maximum amount of time to wait between locking attempts
+	MaxWaitInterval = 5 * time.Minute
+
+	// PollWaitInterval is the usual time to wait between unsuccessful locking attempts
+	PollWaitInterval = 1 * time.Second
+
+	// JitterWaitInterval is the amount of jitter to add when waiting to avoid thundering herds
+	JitterWaitInterval = MinWaitInterval / 2
+
+	// TTL is the interval after which a locked mutex will expire unless refreshed
+	TTL = time.Second * 15
+
+	// RefreshInterval is the interval on which the mutex will be refreshed when locked
+	RefreshInterval = TTL / 2
+)
+
+// MakeLockKey returns the prefixed key used to namespace mutex keys.
+func MakeLockKey(key string) (string, error) {
+	if key == "" {
+		return "", errors.New("must specify valid mutex key")
+	}
+
+	return key, nil
+}
+
+// NextWaitInterval determines how long to wait until the next lock retry.
+func NextWaitInterval(lastWaitInterval time.Duration, err error) time.Duration {
+	nextWaitInterval := lastWaitInterval
+
+	if nextWaitInterval <= 0 {
+		nextWaitInterval = MinWaitInterval
+	}
+
+	if err != nil {
+		nextWaitInterval *= 2
+		if nextWaitInterval > MaxWaitInterval {
+			nextWaitInterval = MaxWaitInterval
+		}
+	} else {
+		nextWaitInterval = PollWaitInterval
+	}
+
+	// Add some jitter to avoid unnecessary collision between competing other instances.
+	nextWaitInterval += time.Duration(rand.Int63n(int64(JitterWaitInterval)) - int64(JitterWaitInterval)/2)
+
+	return nextWaitInterval
+}
+
+type Mutex interface {
+	Lock()
+	LockWithContext(ctx context.Context) error
+	Unlock()
+}
+
+type Lockable interface {
+	DriverName() string
+}

--- a/drivers/lock_test.go
+++ b/drivers/lock_test.go
@@ -1,0 +1,54 @@
+package drivers
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeLockKey(t *testing.T) {
+	t.Run("fails when empty", func(t *testing.T) {
+		key, err := MakeLockKey("")
+		assert.Error(t, err)
+		assert.Empty(t, key)
+	})
+
+	t.Run("not-empty", func(t *testing.T) {
+		testCases := map[string]string{
+			"key":   "key",
+			"other": "other",
+		}
+
+		for key, expected := range testCases {
+			actual, err := MakeLockKey(key)
+			require.NoError(t, err)
+			assert.Equal(t, expected, actual)
+		}
+	})
+}
+
+func TestNextWaitInterval(t *testing.T) {
+	t.Run("should increase the wait time", func(t *testing.T) {
+		interval := time.Second
+		err := errors.New("e")
+		for i := 0; i < 5; i++ {
+			pre := interval
+			interval = NextWaitInterval(interval, err)
+			require.True(t, pre < interval)
+		}
+	})
+
+	t.Run("should stop increasing the wait time if reached to max", func(t *testing.T) {
+		err := errors.New("e")
+		interval := NextWaitInterval(maxWaitInterval, err)
+		require.True(t, interval <= maxWaitInterval)
+	})
+
+	t.Run("should return default interval if no error", func(t *testing.T) {
+		interval := NextWaitInterval(maxWaitInterval, nil)
+		require.True(t, interval <= pollWaitInterval)
+	})
+}

--- a/drivers/mysql/lock.go
+++ b/drivers/mysql/lock.go
@@ -1,0 +1,194 @@
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/go-morph/morph/drivers"
+	"github.com/pkg/errors"
+)
+
+// Mutex is similar to sync.Mutex, except usable by morph to lock the db.
+//
+// Pick a unique name for each mutex your plugin requires.
+//
+// A Mutex must not be copied after first use.
+type Mutex struct {
+	key string
+
+	// lock guards the variables used to manage the refresh task, and is not itself related to
+	// the db lock.
+	lock        sync.Mutex
+	stopRefresh chan bool
+	refreshDone chan bool
+	conn        *sql.Conn
+}
+
+// NewMutex creates a mutex with the given key name.
+//
+// returns error if key is empty.
+func NewMutex(key string, driver drivers.Driver) (*Mutex, error) {
+	key, err := drivers.MakeLockKey(key)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), drivers.TTL)
+	defer cancel()
+
+	ms, ok := driver.(*mysql)
+	if !ok {
+		return nil, errors.New("incorrect implementation of the driver")
+	}
+
+	createTableIfNotExistsQuery := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (Id varchar(64) NOT NULL, ExpireAt bigint(20) NOT NULL, PRIMARY KEY (Id)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", drivers.MutexTableName)
+	if _, err = ms.conn.ExecContext(ctx, createTableIfNotExistsQuery); err != nil {
+		return nil, err
+	}
+
+	return &Mutex{
+		key:  key,
+		conn: ms.conn,
+	}, nil
+}
+
+// lock makes a single attempt to lock the mutex, returning true only if successful.
+func (m *Mutex) tryLock(ctx context.Context) (bool, error) {
+	now := time.Now()
+	query := fmt.Sprintf("INSERT INTO %s (Id, ExpireAt) VALUES ('%s', %d)", drivers.MutexTableName, m.key, now.Add(drivers.TTL).Unix())
+	if _, err := m.conn.ExecContext(ctx, query); err != nil {
+		err2 := m.releaseLock(ctx, now)
+		if err2 == nil {
+			// lock has been released due to expiration
+			return true, nil
+		}
+		return false, errors.Wrapf(err, "failed to lock mutex")
+	}
+
+	return true, nil
+}
+
+func (m *Mutex) releaseLock(ctx context.Context, t time.Time) error {
+	e, err := m.getExpireAt(ctx)
+	if err != nil {
+		return err
+	}
+
+	if t.Unix() < e {
+		return errors.New("could not release the lock")
+	}
+
+	query := fmt.Sprintf("UPDATE %s SET ExpireAt = %d WHERE Id = '%s'", drivers.MutexTableName, t.Add(drivers.TTL).Unix(), m.key)
+	_, err = m.conn.ExecContext(ctx, query)
+	if err != nil {
+		return errors.Wrap(err, "unable to set new expireat for mutex")
+	}
+	return nil
+}
+
+func (m *Mutex) getExpireAt(ctx context.Context) (int64, error) {
+	var expireAt int64
+	query := fmt.Sprintf("SELECT ExpireAt FROM %s WHERE Id = '%s'", drivers.MutexTableName, m.key)
+	err := m.conn.QueryRowContext(ctx, query).Scan(&expireAt)
+	if err != nil {
+		return -1, errors.Wrap(err, "failed to fetch mutex from db")
+	}
+
+	return expireAt, nil
+}
+
+// refreshLock rewrites the lock key value with a new expiry, returning nil only if successful.
+func (m *Mutex) refreshLock(ctx context.Context) error {
+	e, err := m.getExpireAt(ctx)
+	if err != nil {
+		return err
+	}
+
+	tmp := time.Unix(e, 0)
+	query := fmt.Sprintf("UPDATE %s SET ExpireAt = %d WHERE Id = '%s'", drivers.MutexTableName, tmp.Add(drivers.TTL).Unix(), m.key)
+	_, err = m.conn.ExecContext(ctx, query)
+	if err != nil {
+		return errors.Wrap(err, "unable to refresh expireat for mutex")
+	}
+	return nil
+}
+
+// Lock locks m. If the mutex is already locked by any other morph instance, including the current one,
+// the calling goroutine blocks until the mutex can be locked.
+func (m *Mutex) Lock() {
+	_ = m.LockWithContext(context.Background())
+}
+
+// LockWithContext locks m unless the context is canceled. If the mutex is already locked by any other
+// instance, including the current one, the calling goroutine blocks until the mutex can be locked,
+// or the context is canceled.
+//
+// The mutex is locked only if a nil error is returned.
+func (m *Mutex) LockWithContext(ctx context.Context) error {
+	var waitInterval time.Duration
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(waitInterval):
+		}
+
+		locked, err := m.tryLock(ctx)
+		if err != nil {
+			waitInterval = drivers.NextWaitInterval(waitInterval, err)
+			continue
+		} else if !locked {
+			waitInterval = drivers.NextWaitInterval(waitInterval, err)
+			continue
+		}
+
+		stop := make(chan bool)
+		done := make(chan bool)
+		go func() {
+			defer close(done)
+			t := time.NewTicker(drivers.RefreshInterval)
+			for {
+				select {
+				case <-t.C:
+					err := m.refreshLock(ctx)
+					if err != nil {
+						return
+					}
+				case <-stop:
+					return
+				}
+			}
+		}()
+
+		m.lock.Lock()
+		m.stopRefresh = stop
+		m.refreshDone = done
+		m.lock.Unlock()
+
+		return nil
+	}
+}
+
+// Unlock unlocks m. It is a run-time error if m is not locked on entry to Unlock.
+//
+// Just like sync.Mutex, a locked Lock is not associated with a particular goroutine or a process.
+func (m *Mutex) Unlock() {
+	m.lock.Lock()
+	if m.stopRefresh == nil {
+		m.lock.Unlock()
+		panic("mutex has not been acquired")
+	}
+
+	close(m.stopRefresh)
+	m.stopRefresh = nil
+	<-m.refreshDone
+	m.lock.Unlock()
+
+	// If an error occurs deleting, the mutex will still expire, allowing later retry.
+	query := fmt.Sprintf("DELETE FROM %s WHERE Id = %q", drivers.MutexTableName, m.key)
+	_, _ = m.conn.ExecContext(context.Background(), query)
+}

--- a/drivers/mysql/lock.go
+++ b/drivers/mysql/lock.go
@@ -3,12 +3,12 @@ package mysql
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/go-morph/morph/drivers"
-	"github.com/pkg/errors"
 )
 
 // Mutex is similar to sync.Mutex, except usable by morph to lock the db.
@@ -17,6 +17,7 @@ import (
 //
 // A Mutex must not be copied after first use.
 type Mutex struct {
+	noCopy
 	key string
 
 	// lock guards the variables used to manage the refresh task, and is not itself related to
@@ -58,43 +59,74 @@ func NewMutex(key string, driver drivers.Driver) (*Mutex, error) {
 // lock makes a single attempt to lock the mutex, returning true only if successful.
 func (m *Mutex) tryLock(ctx context.Context) (bool, error) {
 	now := time.Now()
-	query := fmt.Sprintf("INSERT INTO %s (Id, ExpireAt) VALUES ('%s', %d)", drivers.MutexTableName, m.key, now.Add(drivers.TTL).Unix())
-	if _, err := m.conn.ExecContext(ctx, query); err != nil {
-		err2 := m.releaseLock(ctx, now)
-		if err2 == nil {
-			// lock has been released due to expiration
+	tx, err := m.conn.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+
+	query := fmt.Sprintf("INSERT INTO %s (Id, ExpireAt) VALUES (?, ?)", drivers.MutexTableName)
+	if _, err := tx.Exec(query, m.key, now.Add(drivers.TTL).Unix()); err != nil {
+		err2 := m.releaseLock(tx, now)
+		if err2 == nil { // lock has been released due to expiration
 			return true, nil
 		}
-		return false, errors.Wrapf(err, "failed to lock mutex")
+
+		return false, fmt.Errorf("failed to lock mutex: %w", err)
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		if txErr := tx.Rollback(); txErr != nil {
+			return false, txErr
+		}
+
+		return false, err
 	}
 
 	return true, nil
 }
 
-func (m *Mutex) releaseLock(ctx context.Context, t time.Time) error {
-	e, err := m.getExpireAt(ctx)
+func (m *Mutex) releaseLock(tx *sql.Tx, t time.Time) error {
+	e, err := m.getExpireAt(tx)
 	if err != nil {
 		return err
 	}
 
 	if t.Unix() < e {
+		if txErr := tx.Rollback(); txErr != nil {
+			return fmt.Errorf("could not rollback: %w", txErr)
+		}
+
 		return errors.New("could not release the lock")
 	}
 
-	query := fmt.Sprintf("UPDATE %s SET ExpireAt = %d WHERE Id = '%s'", drivers.MutexTableName, t.Add(drivers.TTL).Unix(), m.key)
-	_, err = m.conn.ExecContext(ctx, query)
-	if err != nil {
-		return errors.Wrap(err, "unable to set new expireat for mutex")
+	query := fmt.Sprintf("UPDATE %s SET ExpireAt = ? WHERE Id = ?", drivers.MutexTableName)
+	if err = executeTx(tx, query, t.Add(drivers.TTL).Unix(), m.key); err != nil {
+		return err
 	}
+
+	err = tx.Commit()
+	if err != nil {
+		if txErr := tx.Rollback(); txErr != nil {
+			return fmt.Errorf("could not rollback transaction: %w", txErr)
+		}
+
+		return fmt.Errorf("unable to set new expireat for mutex: %w", err)
+	}
+
 	return nil
 }
 
-func (m *Mutex) getExpireAt(ctx context.Context) (int64, error) {
+func (m *Mutex) getExpireAt(tx *sql.Tx) (int64, error) {
 	var expireAt int64
-	query := fmt.Sprintf("SELECT ExpireAt FROM %s WHERE Id = '%s'", drivers.MutexTableName, m.key)
-	err := m.conn.QueryRowContext(ctx, query).Scan(&expireAt)
+	query := fmt.Sprintf("SELECT ExpireAt FROM %s WHERE Id = ?", drivers.MutexTableName)
+	err := tx.QueryRow(query, m.key).Scan(&expireAt)
 	if err != nil {
-		return -1, errors.Wrap(err, "failed to fetch mutex from db")
+		if txErr := tx.Rollback(); txErr != nil {
+			return -1, fmt.Errorf("could not rollback: %w", txErr)
+		}
+
+		return -1, fmt.Errorf("failed to fetch mutex from db: %w", err)
 	}
 
 	return expireAt, nil
@@ -102,17 +134,31 @@ func (m *Mutex) getExpireAt(ctx context.Context) (int64, error) {
 
 // refreshLock rewrites the lock key value with a new expiry, returning nil only if successful.
 func (m *Mutex) refreshLock(ctx context.Context) error {
-	e, err := m.getExpireAt(ctx)
+	tx, err := m.conn.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	e, err := m.getExpireAt(tx)
 	if err != nil {
 		return err
 	}
 
 	tmp := time.Unix(e, 0)
-	query := fmt.Sprintf("UPDATE %s SET ExpireAt = %d WHERE Id = '%s'", drivers.MutexTableName, tmp.Add(drivers.TTL).Unix(), m.key)
-	_, err = m.conn.ExecContext(ctx, query)
-	if err != nil {
-		return errors.Wrap(err, "unable to refresh expireat for mutex")
+	query := fmt.Sprintf("UPDATE %s SET ExpireAt = ? WHERE Id = ?", drivers.MutexTableName)
+	if err = executeTx(tx, query, tmp.Add(drivers.TTL).Unix(), m.key); err != nil {
+		return err
 	}
+
+	err = tx.Commit()
+	if err != nil {
+		if txErr := tx.Rollback(); txErr != nil {
+			return fmt.Errorf("could not rollback: %w", txErr)
+		}
+
+		return fmt.Errorf("unable to refresh expireat for mutex: %w", err)
+	}
+
 	return nil
 }
 
@@ -137,40 +183,39 @@ func (m *Mutex) LockWithContext(ctx context.Context) error {
 		case <-time.After(waitInterval):
 		}
 
-		locked, err := m.tryLock(ctx)
-		if err != nil {
-			waitInterval = drivers.NextWaitInterval(waitInterval, err)
-			continue
-		} else if !locked {
+		ok, err := m.tryLock(ctx)
+		if err != nil || !ok {
 			waitInterval = drivers.NextWaitInterval(waitInterval, err)
 			continue
 		}
 
-		stop := make(chan bool)
-		done := make(chan bool)
-		go func() {
-			defer close(done)
-			t := time.NewTicker(drivers.RefreshInterval)
-			for {
-				select {
-				case <-t.C:
-					err := m.refreshLock(ctx)
-					if err != nil {
-						return
-					}
-				case <-stop:
+		break
+	}
+
+	stop := make(chan bool)
+	done := make(chan bool)
+	go func() {
+		defer close(done)
+		t := time.NewTicker(drivers.RefreshInterval)
+		for {
+			select {
+			case <-t.C:
+				err := m.refreshLock(ctx)
+				if err != nil {
 					return
 				}
+			case <-stop:
+				return
 			}
-		}()
+		}
+	}()
 
-		m.lock.Lock()
-		m.stopRefresh = stop
-		m.refreshDone = done
-		m.lock.Unlock()
+	m.lock.Lock()
+	m.stopRefresh = stop
+	m.refreshDone = done
+	m.lock.Unlock()
 
-		return nil
-	}
+	return nil
 }
 
 // Unlock unlocks m. It is a run-time error if m is not locked on entry to Unlock.
@@ -189,6 +234,28 @@ func (m *Mutex) Unlock() {
 	m.lock.Unlock()
 
 	// If an error occurs deleting, the mutex will still expire, allowing later retry.
-	query := fmt.Sprintf("DELETE FROM %s WHERE Id = %q", drivers.MutexTableName, m.key)
-	_, _ = m.conn.ExecContext(context.Background(), query)
+	query := fmt.Sprintf("DELETE FROM %s WHERE Id = ?", drivers.MutexTableName)
+	_, _ = m.conn.ExecContext(context.Background(), query, m.key)
 }
+
+func executeTx(tx *sql.Tx, query string, args ...interface{}) error {
+	if _, err := tx.Exec(query, args...); err != nil {
+		if txErr := tx.Rollback(); txErr != nil {
+			return fmt.Errorf("could not rollback transaction: %w", txErr)
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+// noCopy may be embedded into structs which must not be copied
+// after the first use.
+//
+// See https://golang.org/issues/8005#issuecomment-190753527
+// for details.
+type noCopy struct{}
+
+// Lock is a no-op used by -copylocks checker from `go vet`.
+func (*noCopy) Lock() {}

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -105,6 +105,10 @@ func (driver *mysql) Ping() error {
 	return driver.conn.PingContext(ctx)
 }
 
+func (mysql) DriverName() string {
+	return driverName
+}
+
 func (driver *mysql) Close() error {
 	if driver.conn != nil {
 		if err := driver.conn.Close(); err != nil {

--- a/drivers/mysql/mysql_test.go
+++ b/drivers/mysql/mysql_test.go
@@ -72,7 +72,8 @@ func (suite *MysqlTestSuite) AfterTest(_, _ string) {
 
 func (suite *MysqlTestSuite) InitializeDriver(connURL string) (drivers.Driver, func()) {
 	connectedDriver, err := Open(connURL)
-	suite.Assert().NoError(err, "should not error when connecting to database from url")
+	suite.Require().NoError(err, "should not error when connecting to database from url")
+	suite.Require().NotNil(connectedDriver)
 
 	return connectedDriver, func() {
 		err = connectedDriver.Close()

--- a/drivers/postgres/lock.go
+++ b/drivers/postgres/lock.go
@@ -1,0 +1,194 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/go-morph/morph/drivers"
+	"github.com/pkg/errors"
+)
+
+// Mutex is similar to sync.Mutex, except usable by morph to lock the db.
+//
+// Pick a unique name for each mutex your plugin requires.
+//
+// A Mutex must not be copied after first use.
+type Mutex struct {
+	key string
+
+	// lock guards the variables used to manage the refresh task, and is not itself related to
+	// the db lock.
+	lock        sync.Mutex
+	stopRefresh chan bool
+	refreshDone chan bool
+	conn        *sql.Conn
+}
+
+// NewMutex creates a mutex with the given key name.
+//
+// returns error if key is empty.
+func NewMutex(key string, driver drivers.Driver) (*Mutex, error) {
+	key, err := drivers.MakeLockKey(key)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), drivers.TTL)
+	defer cancel()
+
+	ps, ok := driver.(*postgres)
+	if !ok {
+		return nil, errors.New("incorrect implementation of the driver")
+	}
+
+	createTableIfNotExistsQuery := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (id varchar(64) PRIMARY KEY, expireat bigint);", drivers.MutexTableName)
+	if _, err = ps.conn.ExecContext(ctx, createTableIfNotExistsQuery); err != nil {
+		return nil, err
+	}
+
+	return &Mutex{
+		key:  key,
+		conn: ps.conn,
+	}, nil
+}
+
+// lock makes a single attempt to lock the mutex, returning true only if successful.
+func (m *Mutex) tryLock(ctx context.Context) (bool, error) {
+	now := time.Now()
+	query := fmt.Sprintf("INSERT INTO %s (id, expireat) VALUES ('%s', %d)", drivers.MutexTableName, m.key, now.Add(drivers.TTL).Unix())
+	if _, err := m.conn.ExecContext(ctx, query); err != nil {
+		err2 := m.releaseLock(ctx, now)
+		if err2 == nil {
+			// lock has been released due to expiration
+			return true, nil
+		}
+		return false, errors.Wrapf(err, "failed to lock mutex")
+	}
+
+	return true, nil
+}
+
+func (m *Mutex) releaseLock(ctx context.Context, t time.Time) error {
+	e, err := m.getExpireAt(ctx)
+	if err != nil {
+		return err
+	}
+
+	if t.Unix() < e {
+		return errors.New("could not release the lock")
+	}
+
+	query := fmt.Sprintf("UPDATE %s SET expireat = %d WHERE id = '%s'", drivers.MutexTableName, t.Add(drivers.TTL).Unix(), m.key)
+	_, err = m.conn.ExecContext(ctx, query)
+	if err != nil {
+		return errors.Wrap(err, "unable to set new expireat for mutex")
+	}
+	return nil
+}
+
+func (m *Mutex) getExpireAt(ctx context.Context) (int64, error) {
+	var expireAt int64
+	query := fmt.Sprintf("SELECT expireat FROM %s WHERE id = '%s'", drivers.MutexTableName, m.key)
+	err := m.conn.QueryRowContext(ctx, query).Scan(&expireAt)
+	if err != nil {
+		return -1, errors.Wrap(err, "failed to fetch mutex from db")
+	}
+
+	return expireAt, nil
+}
+
+// refreshLock rewrites the lock key value with a new expiry, returning nil only if successful.
+func (m *Mutex) refreshLock(ctx context.Context) error {
+	e, err := m.getExpireAt(ctx)
+	if err != nil {
+		return err
+	}
+
+	tmp := time.Unix(e, 0)
+	query := fmt.Sprintf("UPDATE %s SET expireat = %d WHERE id = '%s'", drivers.MutexTableName, tmp.Add(drivers.TTL).Unix(), m.key)
+	_, err = m.conn.ExecContext(ctx, query)
+	if err != nil {
+		return errors.Wrap(err, "unable to refresh expireat for mutex")
+	}
+	return nil
+}
+
+// Lock locks m. If the mutex is already locked by any other morph instance, including the current one,
+// the calling goroutine blocks until the mutex can be locked.
+func (m *Mutex) Lock() {
+	_ = m.LockWithContext(context.Background())
+}
+
+// LockWithContext locks m unless the context is canceled. If the mutex is already locked by any other
+// instance, including the current one, the calling goroutine blocks until the mutex can be locked,
+// or the context is canceled.
+//
+// The mutex is locked only if a nil error is returned.
+func (m *Mutex) LockWithContext(ctx context.Context) error {
+	var waitInterval time.Duration
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(waitInterval):
+		}
+
+		locked, err := m.tryLock(ctx)
+		if err != nil {
+			waitInterval = drivers.NextWaitInterval(waitInterval, err)
+			continue
+		} else if !locked {
+			waitInterval = drivers.NextWaitInterval(waitInterval, err)
+			continue
+		}
+
+		stop := make(chan bool)
+		done := make(chan bool)
+		go func() {
+			defer close(done)
+			t := time.NewTicker(drivers.RefreshInterval)
+			for {
+				select {
+				case <-t.C:
+					err := m.refreshLock(ctx)
+					if err != nil {
+						return
+					}
+				case <-stop:
+					return
+				}
+			}
+		}()
+
+		m.lock.Lock()
+		m.stopRefresh = stop
+		m.refreshDone = done
+		m.lock.Unlock()
+
+		return nil
+	}
+}
+
+// Unlock unlocks m. It is a run-time error if m is not locked on entry to Unlock.
+//
+// Just like sync.Mutex, a locked Lock is not associated with a particular goroutine or a process.
+func (m *Mutex) Unlock() {
+	m.lock.Lock()
+	if m.stopRefresh == nil {
+		m.lock.Unlock()
+		panic("mutex has not been acquired")
+	}
+
+	close(m.stopRefresh)
+	m.stopRefresh = nil
+	<-m.refreshDone
+	m.lock.Unlock()
+
+	// If an error occurs deleting, the mutex will still expire, allowing later retry.
+	query := fmt.Sprintf("DELETE FROM %s WHERE id = %q", drivers.MutexTableName, m.key)
+	_, _ = m.conn.ExecContext(context.Background(), query)
+}

--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -193,6 +193,10 @@ func (pg *postgres) createSchemaTableIfNotExists() (err error) {
 	return nil
 }
 
+func (postgres) DriverName() string {
+	return driverName
+}
+
 func (pg *postgres) Close() error {
 	if pg.conn != nil {
 		if err := pg.conn.Close(); err != nil {

--- a/drivers/postgres/postgres_test.go
+++ b/drivers/postgres/postgres_test.go
@@ -49,7 +49,8 @@ func (suite *PostgresTestSuite) BeforeTest(_, _ string) {
 
 func (suite *PostgresTestSuite) InitializeDriver(connURL string) (drivers.Driver, func()) {
 	connectedDriver, err := Open(connURL)
-	suite.Assert().NoError(err, "should not error when connecting to database from url")
+	suite.Require().NoError(err, "should not error when connecting to database from url")
+	suite.Require().NotNil(connectedDriver)
 
 	return connectedDriver, func() {
 		err = connectedDriver.Close()

--- a/drivers/utils.go
+++ b/drivers/utils.go
@@ -21,7 +21,7 @@ func ExtractCustomParams(conn string, params []string) (map[string]string, error
 }
 
 func RemoveParamsFromURL(conn string, params []string) (string, error) {
-	prefixCorrection := regexp.MustCompile("\\?&+")
+	prefixCorrection := regexp.MustCompile(`\?&+`)
 	repeatedAmber := regexp.MustCompile("&+")
 
 	for _, param := range params {

--- a/morph.go
+++ b/morph.go
@@ -70,14 +70,15 @@ func SetSatementTimeoutInSeconds(n int) EngineOption {
 	}
 }
 
-// WithLockKey creates a lock table in the database so that any other morph instance will ...
+// WithLockKey creates a lock table in the database so that the migrations are
+// guaranteed to be executed from a single instance.
 func WithLockKey(key string) EngineOption {
 	return func(m *Morph) {
 		m.config.LockKey = key
 	}
 }
 
-// New creates a new instance of the migrations engine from an existing db instance and a migrations source
+// New creates a new instance of the migrations engine from an existing db instance and a migrations source.
 func New(driver drivers.Driver, source sources.Source, options ...EngineOption) (*Morph, error) {
 	engine := &Morph{
 		config: defaultConfig,

--- a/sources/file/file.go
+++ b/sources/file/file.go
@@ -70,7 +70,7 @@ func (f *File) readMigrations() error {
 	}
 
 	migrations := []*models.Migration{}
-	walkerr := filepath.Walk(f.path, func(path string, info os.FileInfo, err error) error {
+	walkerr := filepath.Walk(f.path, func(path string, info os.FileInfo, _ error) error {
 		if info.IsDir() {
 			return nil
 		}


### PR DESCRIPTION
We are creating a DB table to store mutex along with an expiration date. The mutex will have an expiration date so that we never lock the migrations in case of an error.

I used the same implementation that is written for mattermost plugin API. We use the `driver` to use it's `db.conn` to execute queries.

The code organization and layout can be improved 😅  