### PR TITLE
morph.go: ban global variables

### DIFF
--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -69,7 +69,7 @@ func Open(connURL string) (drivers.Driver, error) {
 		return nil, &drivers.AppError{Driver: driverName, OrigErr: err, Message: "failed to sanitize url from custom parameters"}
 	}
 
-	driverConfig, err := mergeConfigWithParams(customParams, defaultConfig)
+	driverConfig, err := mergeConfigWithParams(customParams, *defaultConfig)
 	if err != nil {
 		return nil, &drivers.AppError{Driver: driverName, OrigErr: err, Message: "failed to merge custom params to driver config"}
 	}
@@ -368,7 +368,7 @@ func mergeConfigs(config *Config, defaultConfig *Config) *Config {
 	return config
 }
 
-func mergeConfigWithParams(params map[string]string, config *Config) (*Config, error) {
+func mergeConfigWithParams(params map[string]string, config Config) (*Config, error) {
 	var err error
 
 	for _, configKey := range configParams {
@@ -388,7 +388,7 @@ func mergeConfigWithParams(params map[string]string, config *Config) (*Config, e
 		}
 	}
 
-	return config, nil
+	return &config, nil
 }
 
 func (driver *mysql) addMigrationQuery(migration *models.Migration) string {

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -16,13 +16,6 @@ import (
 
 const driverName = "mysql"
 const defaultMigrationMaxSize = 10 * 1 << 20 // 10 MB
-var defaultConfig = &Config{
-	Config: drivers.Config{
-		MigrationsTable:        "db_migrations",
-		StatementTimeoutInSecs: 60,
-		MigrationMaxSize:       defaultMigrationMaxSize,
-	},
-}
 
 // add here any custom driver configuration
 var configParams = []string{
@@ -44,7 +37,7 @@ type mysql struct {
 }
 
 func WithInstance(dbInstance *sql.DB, config *Config) (drivers.Driver, error) {
-	driverConfig := mergeConfigs(config, defaultConfig)
+	driverConfig := mergeConfigs(config, getDefaultConfig())
 
 	conn, err := dbInstance.Conn(context.Background())
 	if err != nil {
@@ -69,7 +62,7 @@ func Open(connURL string) (drivers.Driver, error) {
 		return nil, &drivers.AppError{Driver: driverName, OrigErr: err, Message: "failed to sanitize url from custom parameters"}
 	}
 
-	driverConfig, err := mergeConfigWithParams(customParams, defaultConfig)
+	driverConfig, err := mergeConfigWithParams(customParams, getDefaultConfig())
 	if err != nil {
 		return nil, &drivers.AppError{Driver: driverName, OrigErr: err, Message: "failed to merge custom params to driver config"}
 	}
@@ -370,34 +363,25 @@ func mergeConfigs(config *Config, defaultConfig *Config) *Config {
 
 func mergeConfigWithParams(params map[string]string, config *Config) (*Config, error) {
 	var err error
-	cfg := &Config{
-		Config: drivers.Config{
-			MigrationsTable:        config.MigrationsTable,
-			StatementTimeoutInSecs: config.StatementTimeoutInSecs,
-			MigrationMaxSize:       config.MigrationMaxSize,
-		},
-		databaseName:   config.databaseName,
-		closeDBonClose: config.closeDBonClose,
-	}
 
 	for _, configKey := range configParams {
 		if v, ok := params[configKey]; ok {
 			switch configKey {
 			case "x-migration-max-size":
-				if cfg.MigrationMaxSize, err = strconv.Atoi(v); err != nil {
+				if config.MigrationMaxSize, err = strconv.Atoi(v); err != nil {
 					return nil, errors.New(fmt.Sprintf("failed to cast config param %s of %s", configKey, v))
 				}
 			case "x-migrations-table":
-				cfg.MigrationsTable = v
+				config.MigrationsTable = v
 			case "x-statement-timeout":
-				if cfg.StatementTimeoutInSecs, err = strconv.Atoi(v); err != nil {
+				if config.StatementTimeoutInSecs, err = strconv.Atoi(v); err != nil {
 					return nil, errors.New(fmt.Sprintf("failed to cast config param %s of %s", configKey, v))
 				}
 			}
 		}
 	}
 
-	return cfg, nil
+	return config, nil
 }
 
 func (driver *mysql) addMigrationQuery(migration *models.Migration) string {

--- a/drivers/mysql/mysql_test.go
+++ b/drivers/mysql/mysql_test.go
@@ -95,11 +95,19 @@ func (suite *MysqlTestSuite) TestOpen() {
 	})
 
 	suite.T().Run("when connURL is valid and bare uses default configuration", func(t *testing.T) {
-		connectedDriver, teardown := suite.InitializeDriver(testConnURL)
+		connectedDriver, teardown := suite.InitializeDriver(defaultConnURL)
 		defer teardown()
 
+		cfg := &Config{
+			Config: drivers.Config{
+				MigrationsTable:        defaultConfig.MigrationsTable,
+				StatementTimeoutInSecs: defaultConfig.StatementTimeoutInSecs,
+				MigrationMaxSize:       defaultConfig.MigrationMaxSize,
+			},
+			closeDBonClose: true, // we have created DB from DSN
+		}
 		mysqlDriver := connectedDriver.(*mysql)
-		suite.Assert().EqualValues(defaultConfig, mysqlDriver.config)
+		suite.Assert().EqualValues(cfg, mysqlDriver.config)
 	})
 
 	suite.T().Run("when connURL is valid can override migrations table", func(t *testing.T) {

--- a/drivers/mysql/mysql_test.go
+++ b/drivers/mysql/mysql_test.go
@@ -98,6 +98,7 @@ func (suite *MysqlTestSuite) TestOpen() {
 		connectedDriver, teardown := suite.InitializeDriver(defaultConnURL)
 		defer teardown()
 
+		defaultConfig := getDefaultConfig()
 		cfg := &Config{
 			Config: drivers.Config{
 				MigrationsTable:        defaultConfig.MigrationsTable,
@@ -144,6 +145,8 @@ func (suite *MysqlTestSuite) TestOpen() {
 }
 
 func (suite *MysqlTestSuite) TestCreateSchemaTableIfNotExists() {
+	defaultConfig := getDefaultConfig()
+
 	suite.T().Run("it errors when connection is missing", func(t *testing.T) {
 		driver := &mysql{}
 
@@ -194,6 +197,8 @@ func (suite *MysqlTestSuite) TestCreateSchemaTableIfNotExists() {
 }
 
 func (suite *MysqlTestSuite) TestLock() {
+	defaultConfig := getDefaultConfig()
+
 	connectedDriver, teardown := suite.InitializeDriver(testConnURL)
 	defer teardown()
 
@@ -211,6 +216,8 @@ func (suite *MysqlTestSuite) TestLock() {
 }
 
 func (suite *MysqlTestSuite) TestUnlock() {
+	defaultConfig := getDefaultConfig()
+
 	connectedDriver, teardown := suite.InitializeDriver(testConnURL)
 	defer teardown()
 
@@ -230,6 +237,8 @@ func (suite *MysqlTestSuite) TestUnlock() {
 }
 
 func (suite *MysqlTestSuite) TestAppliedMigrations() {
+	defaultConfig := getDefaultConfig()
+
 	connectedDriver, teardown := suite.InitializeDriver(testConnURL)
 	defer teardown()
 
@@ -252,6 +261,8 @@ func (suite *MysqlTestSuite) TestAppliedMigrations() {
 }
 
 func (suite *MysqlTestSuite) TestApply() {
+	defaultConfig := getDefaultConfig()
+
 	testData := []struct {
 		Scenario                  string
 		PendingMigrations         []*models.Migration

--- a/drivers/mysql/utils.go
+++ b/drivers/mysql/utils.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"github.com/go-morph/morph/drivers"
 	mysqlDriver "github.com/go-sql-driver/mysql"
 )
 
@@ -20,4 +21,14 @@ func extractDatabaseNameFromURL(conn string) (string, error) {
 	}
 
 	return cfg.DBName, nil
+}
+
+func getDefaultConfig() *Config {
+	return &Config{
+		Config: drivers.Config{
+			MigrationsTable:        "db_migrations",
+			StatementTimeoutInSecs: 60,
+			MigrationMaxSize:       defaultMigrationMaxSize,
+		},
+	}
 }

--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -77,7 +77,7 @@ func Open(connURL string) (drivers.Driver, error) {
 		return nil, &drivers.AppError{Driver: driverName, OrigErr: err, Message: "failed to sanitize url from custom parameters"}
 	}
 
-	driverConfig, err := mergeConfigWithParams(customParams, *defaultConfig)
+	driverConfig, err := mergeConfigWithParams(customParams, defaultConfig)
 	if err != nil {
 		return nil, &drivers.AppError{Driver: driverName, OrigErr: err, Message: "failed to merge custom params to driver config"}
 	}
@@ -128,27 +128,37 @@ func currentSchema(conn *sql.Conn, config *Config) (string, error) {
 	return schemaName, nil
 }
 
-func mergeConfigWithParams(params map[string]string, config Config) (*Config, error) {
+func mergeConfigWithParams(params map[string]string, config *Config) (*Config, error) {
 	var err error
+	cfg := &Config{
+		Config: drivers.Config{
+			MigrationsTable:        config.MigrationsTable,
+			StatementTimeoutInSecs: config.StatementTimeoutInSecs,
+			MigrationMaxSize:       config.MigrationMaxSize,
+		},
+		databaseName:   config.databaseName,
+		schemaName:     config.schemaName,
+		closeDBonClose: config.closeDBonClose,
+	}
 
 	for _, configKey := range configParams {
 		if v, ok := params[configKey]; ok {
 			switch configKey {
 			case "x-migration-max-size":
-				if config.MigrationMaxSize, err = strconv.Atoi(v); err != nil {
+				if cfg.MigrationMaxSize, err = strconv.Atoi(v); err != nil {
 					return nil, errors.New(fmt.Sprintf("failed to cast config param %s of %s", configKey, v))
 				}
 			case "x-migrations-table":
-				config.MigrationsTable = v
+				cfg.MigrationsTable = v
 			case "x-statement-timeout":
-				if config.StatementTimeoutInSecs, err = strconv.Atoi(v); err != nil {
+				if cfg.StatementTimeoutInSecs, err = strconv.Atoi(v); err != nil {
 					return nil, errors.New(fmt.Sprintf("failed to cast config param %s of %s", configKey, v))
 				}
 			}
 		}
 	}
 
-	return &config, nil
+	return cfg, nil
 }
 
 func mergeConfigs(config, defaultConfig *Config) *Config {

--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -77,7 +77,7 @@ func Open(connURL string) (drivers.Driver, error) {
 		return nil, &drivers.AppError{Driver: driverName, OrigErr: err, Message: "failed to sanitize url from custom parameters"}
 	}
 
-	driverConfig, err := mergeConfigWithParams(customParams, defaultConfig)
+	driverConfig, err := mergeConfigWithParams(customParams, *defaultConfig)
 	if err != nil {
 		return nil, &drivers.AppError{Driver: driverName, OrigErr: err, Message: "failed to merge custom params to driver config"}
 	}
@@ -128,7 +128,7 @@ func currentSchema(conn *sql.Conn, config *Config) (string, error) {
 	return schemaName, nil
 }
 
-func mergeConfigWithParams(params map[string]string, config *Config) (*Config, error) {
+func mergeConfigWithParams(params map[string]string, config Config) (*Config, error) {
 	var err error
 
 	for _, configKey := range configParams {
@@ -148,7 +148,7 @@ func mergeConfigWithParams(params map[string]string, config *Config) (*Config, e
 		}
 	}
 
-	return config, nil
+	return &config, nil
 }
 
 func mergeConfigs(config, defaultConfig *Config) *Config {

--- a/drivers/postgres/postgres_test.go
+++ b/drivers/postgres/postgres_test.go
@@ -91,8 +91,19 @@ func (suite *PostgresTestSuite) TestOpen() {
 		connectedDriver, teardown := suite.InitializeDriver(testConnURL)
 		defer teardown()
 
+		cfg := &Config{
+			Config: drivers.Config{
+				MigrationsTable:        defaultConfig.MigrationsTable,
+				StatementTimeoutInSecs: defaultConfig.StatementTimeoutInSecs,
+				MigrationMaxSize:       defaultConfig.MigrationMaxSize,
+			},
+			databaseName:   databaseName,
+			schemaName:     "public",
+			closeDBonClose: true, // we have created DB from DSN
+		}
+
 		pgDriver := connectedDriver.(*postgres)
-		suite.Assert().EqualValues(defaultConfig, pgDriver.config)
+		suite.Assert().EqualValues(cfg, pgDriver.config)
 	})
 
 	suite.T().Run("when connURL is valid can override migrations table", func(t *testing.T) {

--- a/drivers/postgres/postgres_test.go
+++ b/drivers/postgres/postgres_test.go
@@ -91,6 +91,7 @@ func (suite *PostgresTestSuite) TestOpen() {
 		connectedDriver, teardown := suite.InitializeDriver(testConnURL)
 		defer teardown()
 
+		defaultConfig := getDefaultConfig()
 		cfg := &Config{
 			Config: drivers.Config{
 				MigrationsTable:        defaultConfig.MigrationsTable,
@@ -141,6 +142,8 @@ func (suite *PostgresTestSuite) TestOpen() {
 }
 
 func (suite *PostgresTestSuite) TestCreateSchemaTableIfNotExists() {
+	defaultConfig := getDefaultConfig()
+
 	suite.T().Run("it errors when connection is missing", func(t *testing.T) {
 		driver := &postgres{}
 
@@ -236,6 +239,8 @@ func (suite *PostgresTestSuite) TestUnlock() {
 }
 
 func (suite *PostgresTestSuite) TestAppliedMigrations() {
+	defaultConfig := getDefaultConfig()
+
 	connectedDriver, teardown := suite.InitializeDriver(testConnURL)
 	defer teardown()
 
@@ -258,6 +263,8 @@ func (suite *PostgresTestSuite) TestAppliedMigrations() {
 }
 
 func (suite *PostgresTestSuite) TestApply() {
+	defaultConfig := getDefaultConfig()
+
 	testData := []struct {
 		Scenario                  string
 		PendingMigrations         []*models.Migration

--- a/drivers/postgres/utils.go
+++ b/drivers/postgres/utils.go
@@ -1,6 +1,10 @@
 package postgres
 
-import "net/url"
+import (
+	"net/url"
+
+	"github.com/go-morph/morph/drivers"
+)
 
 func extractDatabaseNameFromURL(URL string) (string, error) {
 	uri, err := url.Parse(URL)
@@ -9,4 +13,14 @@ func extractDatabaseNameFromURL(URL string) (string, error) {
 	}
 
 	return uri.Path[1:], nil
+}
+
+func getDefaultConfig() *Config {
+	return &Config{
+		Config: drivers.Config{
+			MigrationsTable:        "db_migrations",
+			StatementTimeoutInSecs: 60,
+			MigrationMaxSize:       defaultMigrationMaxSize,
+		},
+	}
 }

--- a/morph.go
+++ b/morph.go
@@ -42,10 +42,6 @@ type Config struct {
 
 type EngineOption func(*Morph)
 
-var defaultConfig = &Config{
-	Logger: log.New(os.Stderr, "", log.LstdFlags), // add default logger
-}
-
 func WithLogger(logger *log.Logger) EngineOption {
 	return func(m *Morph) {
 		m.config.Logger = logger
@@ -82,7 +78,9 @@ func WithLock(key string) EngineOption {
 // New creates a new instance of the migrations engine from an existing db instance and a migrations source.
 func New(ctx context.Context, driver drivers.Driver, source sources.Source, options ...EngineOption) (*Morph, error) {
 	engine := &Morph{
-		config: defaultConfig,
+		config: &Config{
+			Logger: log.New(os.Stderr, "", log.LstdFlags), // add default logger
+		},
 		source: source,
 		driver: driver,
 	}


### PR DESCRIPTION
This was causing data races on mattermost-server tests.

For context: https://app.circleci.com/pipelines/github/mattermost/mattermost-server/30298/workflows/4b19b316-d69d-4ba0-a0c6-7f37d468d8bd/jobs/224847