### PR TITLE
MM-41151: Do not use advisory locks if driver implements Lockable

### DIFF
--- a/drivers/lock.go
+++ b/drivers/lock.go
@@ -76,3 +76,10 @@ type Locker interface {
 type Lockable interface {
 	DriverName() string
 }
+
+// IsLockable returns whether the given instance satisfies
+// drivers.Lockable or not.
+func IsLockable(x interface{}) bool {
+	_, ok := x.(Lockable)
+	return ok
+}

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -132,6 +132,11 @@ func (driver *mysql) Close() error {
 }
 
 func (driver *mysql) Lock() error {
+	if drivers.IsLockable(driver) {
+		// Supports lockable, so already locked at the global level.
+		return nil
+	}
+
 	aid, err := drivers.GenerateAdvisoryLockID(driver.config.databaseName, driver.config.MigrationsTable)
 	if err != nil {
 		return err
@@ -167,6 +172,11 @@ func (driver *mysql) Lock() error {
 }
 
 func (driver *mysql) Unlock() error {
+	if drivers.IsLockable(driver) {
+		// Supports lockable, so already locked at the global level.
+		return nil
+	}
+
 	aid, err := drivers.GenerateAdvisoryLockID(driver.config.databaseName, driver.config.MigrationsTable)
 	if err != nil {
 		return err

--- a/drivers/mysql/mysql_test.go
+++ b/drivers/mysql/mysql_test.go
@@ -196,25 +196,6 @@ func (suite *MysqlTestSuite) TestCreateSchemaTableIfNotExists() {
 	})
 }
 
-func (suite *MysqlTestSuite) TestLock() {
-	defaultConfig := getDefaultConfig()
-
-	connectedDriver, teardown := suite.InitializeDriver(testConnURL)
-	defer teardown()
-
-	err := connectedDriver.Lock()
-	suite.Require().NoError(err, "should not error when attempting to acquire an advisory lock")
-	defer connectedDriver.Unlock()
-
-	advisoryLockID, err := drivers.GenerateAdvisoryLockID("morph_test", defaultConfig.MigrationsTable)
-	suite.Require().NoError(err, "should not error when generating generate advisory lock id")
-
-	var result int
-	err = suite.db.QueryRow(fmt.Sprintf("SELECT COUNT(*) FROM performance_schema.metadata_locks WHERE OBJECT_TYPE = 'USER LEVEL LOCK' AND LOCK_STATUS = 'GRANTED' AND OBJECT_NAME = '%s'", advisoryLockID)).Scan(&result)
-	suite.Require().NoError(err, "should not error querying performance_schema.metadata_locks")
-	suite.Require().Equal(1, result, "advisory lock should be acquired")
-}
-
 func (suite *MysqlTestSuite) TestUnlock() {
 	defaultConfig := getDefaultConfig()
 

--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -220,6 +220,11 @@ func (pg *postgres) Close() error {
 }
 
 func (pg *postgres) Lock() error {
+	if drivers.IsLockable(pg) {
+		// Supports lockable, so already locked at the global level.
+		return nil
+	}
+
 	aid, err := drivers.GenerateAdvisoryLockID(pg.config.databaseName, pg.config.schemaName)
 	if err != nil {
 		return err
@@ -244,6 +249,11 @@ func (pg *postgres) Lock() error {
 }
 
 func (pg *postgres) Unlock() error {
+	if drivers.IsLockable(pg) {
+		// Supports lockable, so already locked at the global level.
+		return nil
+	}
+
 	aid, err := drivers.GenerateAdvisoryLockID(pg.config.databaseName, pg.config.schemaName)
 	if err != nil {
 		return err

--- a/drivers/postgres/postgres_test.go
+++ b/drivers/postgres/postgres_test.go
@@ -202,23 +202,6 @@ func (suite *PostgresTestSuite) TestCreateSchemaTableIfNotExists() {
 	})
 }
 
-func (suite *PostgresTestSuite) TestLock() {
-	connectedDriver, teardown := suite.InitializeDriver(testConnURL)
-	defer teardown()
-
-	err := connectedDriver.Lock()
-	suite.Require().NoError(err, "should not error when attempting to acquire an advisory lock")
-	defer connectedDriver.Unlock()
-
-	advisoryLockID, err := drivers.GenerateAdvisoryLockID("morph_test", "public")
-	suite.Require().NoError(err, "should not error when generating generate advisory lock id")
-
-	var result int
-	err = suite.db.QueryRow(fmt.Sprintf("SELECT COUNT(*) FROM pg_locks WHERE locktype = 'advisory' AND granted = true AND objid = '%s'", advisoryLockID)).Scan(&result)
-	suite.Require().NoError(err, "should not error querying pg_locks")
-	suite.Require().Equal(1, result, "advisory lock should be acquired")
-}
-
 func (suite *PostgresTestSuite) TestUnlock() {
 	connectedDriver, teardown := suite.InitializeDriver(testConnURL)
 	defer teardown()

--- a/morph.go
+++ b/morph.go
@@ -76,6 +76,7 @@ func WithLock(key string) EngineOption {
 }
 
 // New creates a new instance of the migrations engine from an existing db instance and a migrations source.
+// If the driver implements the Lockable interface, it will also wait until it has acquired a lock.
 func New(ctx context.Context, driver drivers.Driver, source sources.Source, options ...EngineOption) (*Morph, error) {
 	engine := &Morph{
 		config: &Config{


### PR DESCRIPTION
If a driver implements the Lockable interface, then we
already use a manual table lock and hold it until all
the migrations are over. So there's no need to additionally
acquire advisory locks. They are just redundant.

Therefore, we maintain two modes of operation. Either a driver
implements Lockable, in which case we avoid advisory locks.
Or a driver does not do that, in which case we do use advisory locks
to do the locking for us.

It is up to the driver implementor to do as they wish.

There are still some things to sort out from a driver perspective because
logically speaking, we should just remove the advisory lock code. But then,
we break the `driver.Driver` interface.

Later, one of the things that we can do is compose interfaces into larger ones.
We can keep `driver.Driver` with just the basic one, and compose a larger one
with `driver.Locker` and call it `driver.DriveLocker` or something like that, and
then decide whether to call the global lock or advisory locks from the code.

https://mattermost.atlassian.net/browse/MM-41151