### PR TITLE
MM-41143: Use the logger interface in config

### DIFF
--- a/color_logger.go
+++ b/color_logger.go
@@ -1,6 +1,8 @@
 package morph
 
 import (
+	"log"
+
 	"github.com/fatih/color"
 )
 
@@ -15,4 +17,20 @@ var (
 type Logger interface {
 	Printf(format string, v ...interface{})
 	Println(v ...interface{})
+}
+
+type colorLogger struct {
+	log *log.Logger
+}
+
+func newColorLogger(log *log.Logger) *colorLogger {
+	return &colorLogger{log: log}
+}
+
+func (l *colorLogger) Printf(format string, v ...interface{}) {
+	l.log.Println(InfoLoggerLight.Sprintf(format, v...))
+}
+
+func (l *colorLogger) Println(v ...interface{}) {
+	l.log.Println(InfoLoggerLight.Sprint(v...))
 }

--- a/morph.go
+++ b/morph.go
@@ -80,7 +80,7 @@ func WithLock(key string) EngineOption {
 func New(ctx context.Context, driver drivers.Driver, source sources.Source, options ...EngineOption) (*Morph, error) {
 	engine := &Morph{
 		config: &Config{
-			Logger: log.New(os.Stderr, "", log.LstdFlags), // add default logger
+			Logger: newColorLogger(log.New(os.Stderr, "", log.LstdFlags)), // add default logger
 		},
 		source: source,
 		driver: driver,

--- a/morph.go
+++ b/morph.go
@@ -42,7 +42,7 @@ type Config struct {
 
 type EngineOption func(*Morph)
 
-func WithLogger(logger *log.Logger) EngineOption {
+func WithLogger(logger Logger) EngineOption {
 	return func(m *Morph) {
 		m.config.Logger = logger
 	}
@@ -164,14 +164,14 @@ func (m *Morph) Apply(limit int) (int, error) {
 	for i := 0; i < steps; i++ {
 		start := time.Now()
 		migrationName := migrations[i].Name
-		m.config.Logger.Println(InfoLoggerLight.Sprint(formatProgress(fmt.Sprintf(migrationProgressStart, migrationName))))
+		m.config.Logger.Println(formatProgress(fmt.Sprintf(migrationProgressStart, migrationName)))
 		if err := m.driver.Apply(migrations[i], true); err != nil {
 			return applied, err
 		}
 
 		applied++
 		elapsed := time.Since(start)
-		m.config.Logger.Println(InfoLoggerLight.Sprint(formatProgress(fmt.Sprintf(migrationProgressFinished, migrationName, fmt.Sprintf("%.4fs", elapsed.Seconds())))))
+		m.config.Logger.Println(formatProgress(fmt.Sprintf(migrationProgressFinished, migrationName, fmt.Sprintf("%.4fs", elapsed.Seconds()))))
 	}
 
 	return applied, nil
@@ -204,7 +204,7 @@ func (m *Morph) ApplyDown(limit int) (int, error) {
 	for i := 0; i < steps; i++ {
 		start := time.Now()
 		migrationName := sortedMigrations[i].Name
-		m.config.Logger.Println(InfoLoggerLight.Sprint(formatProgress(fmt.Sprintf(migrationProgressStart, migrationName))))
+		m.config.Logger.Println(formatProgress(fmt.Sprintf(migrationProgressStart, migrationName)))
 
 		down := downMigrations[migrationName]
 		if err := m.driver.Apply(down, true); err != nil {
@@ -213,7 +213,7 @@ func (m *Morph) ApplyDown(limit int) (int, error) {
 
 		applied++
 		elapsed := time.Since(start)
-		m.config.Logger.Println(InfoLoggerLight.Sprint(formatProgress(fmt.Sprintf(migrationProgressFinished, migrationName, fmt.Sprintf("%.4fs", elapsed.Seconds())))))
+		m.config.Logger.Println(formatProgress(fmt.Sprintf(migrationProgressFinished, migrationName, fmt.Sprintf("%.4fs", elapsed.Seconds()))))
 	}
 
 	return applied, nil


### PR DESCRIPTION
We already used the interface in the config field
but not in the function argument. This is just making
it more consistent.

Also we remove color logging because it messes up
the logs when they are redirected to file. If needed,
the logger can add color to the log.

https://mattermost.atlassian.net/browse/MM-41143
