### PR TITLE
MM-41218: Improve error logging

### DIFF
--- a/drivers/lock.go
+++ b/drivers/lock.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"math/rand"
-	"sync"
 	"time"
 )
 
@@ -64,7 +63,8 @@ func NextWaitInterval(lastWaitInterval time.Duration, err error) time.Duration {
 }
 
 type Locker interface {
-	sync.Locker
+	Lock() error
+	Unlock() error
 	// LockWithContext locks m unless the context is canceled. If the mutex is already locked by any other
 	// instance, including the current one, the calling goroutine blocks until the mutex can be locked,
 	// or the context is canceled.

--- a/drivers/mysql/lock.go
+++ b/drivers/mysql/lock.go
@@ -169,8 +169,8 @@ func (m *Mutex) refreshLock(ctx context.Context) error {
 
 // Lock locks m. If the mutex is already locked by any other morph instance, including the current one,
 // the calling goroutine blocks until the mutex can be locked.
-func (m *Mutex) Lock() {
-	_ = m.LockWithContext(context.Background())
+func (m *Mutex) Lock() error {
+	return m.LockWithContext(context.Background())
 }
 
 // LockWithContext locks m unless the context is canceled. If the mutex is already locked by any other
@@ -226,7 +226,7 @@ func (m *Mutex) LockWithContext(ctx context.Context) error {
 // Unlock unlocks m. It is a run-time error if m is not locked on entry to Unlock.
 //
 // Just like sync.Mutex, a locked Lock is not associated with a particular goroutine or a process.
-func (m *Mutex) Unlock() {
+func (m *Mutex) Unlock() error {
 	m.lock.Lock()
 	if m.stopRefresh == nil {
 		m.lock.Unlock()
@@ -242,7 +242,8 @@ func (m *Mutex) Unlock() {
 
 	// If an error occurs deleting, the mutex will still expire, allowing later retry.
 	query := fmt.Sprintf("DELETE FROM %s WHERE Id = ?", drivers.MutexTableName)
-	_, _ = m.conn.ExecContext(context.Background(), query, m.key)
+	_, err := m.conn.ExecContext(context.Background(), query, m.key)
+	return err
 }
 
 func executeTx(tx *sql.Tx, query string, args ...interface{}) error {

--- a/drivers/postgres/lock.go
+++ b/drivers/postgres/lock.go
@@ -169,8 +169,8 @@ func (m *Mutex) refreshLock(ctx context.Context) error {
 
 // Lock locks m. If the mutex is already locked by any other morph instance, including the current one,
 // the calling goroutine blocks until the mutex can be locked.
-func (m *Mutex) Lock() {
-	_ = m.LockWithContext(context.Background())
+func (m *Mutex) Lock() error {
+	return m.LockWithContext(context.Background())
 }
 
 // LockWithContext locks m unless the context is canceled. If the mutex is already locked by any other
@@ -226,7 +226,7 @@ func (m *Mutex) LockWithContext(ctx context.Context) error {
 // Unlock unlocks m. It is a run-time error if m is not locked on entry to Unlock.
 //
 // Just like sync.Mutex, a locked Lock is not associated with a particular goroutine or a process.
-func (m *Mutex) Unlock() {
+func (m *Mutex) Unlock() error {
 	m.lock.Lock()
 	if m.stopRefresh == nil {
 		m.lock.Unlock()
@@ -242,7 +242,8 @@ func (m *Mutex) Unlock() {
 
 	// If an error occurs deleting, the mutex will still expire, allowing later retry.
 	query := fmt.Sprintf("DELETE FROM %s WHERE id = $1", drivers.MutexTableName)
-	_, _ = m.conn.ExecContext(context.Background(), query, m.key)
+	_, err := m.conn.ExecContext(context.Background(), query, m.key)
+	return err
 }
 
 func executeTx(tx *sql.Tx, query string, args ...interface{}) error {

--- a/morph.go
+++ b/morph.go
@@ -120,7 +120,10 @@ func New(ctx context.Context, driver drivers.Driver, source sources.Source, opti
 // Close closes the underlying database connection of the engine.
 func (m *Morph) Close() error {
 	if m.mutex != nil {
-		m.mutex.Unlock()
+		err := m.mutex.Unlock()
+		if err != nil {
+			return err
+		}
 	}
 
 	return m.driver.Close()

--- a/morph.go
+++ b/morph.go
@@ -108,7 +108,10 @@ func New(ctx context.Context, driver drivers.Driver, source sources.Source, opti
 		}
 
 		engine.mutex = mx
-		_ = mx.LockWithContext(ctx)
+		err = mx.LockWithContext(ctx)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return engine, nil


### PR DESCRIPTION
We move away from the sync.Locker interface
to properly bubble up errors to the caller.

https://mattermost.atlassian.net/browse/MM-41218
